### PR TITLE
Add Sensor Fusion teaching event at Centrale Nantes (March 2026)

### DIFF
--- a/content/event/ecn26/index.md
+++ b/content/event/ecn26/index.md
@@ -1,0 +1,53 @@
+---
+title: "Teaching: Sensor Fusion and Scene Understanding for AD/ADAS at Centrale Nantes"
+
+event: École Centrale Nantes
+event_url: https://www.ec-nantes.fr/
+
+location: ECN
+address:
+  street: 828 Boulevard des Maréchaux
+  city: Palaiseau
+  region: Ile-de-France
+  postcode: '91120'
+  country: France
+
+summary: Lectio magistralis delivered for the ECN Datasim course, introducing key concepts in sensor fusion and scene understanding for autonomous driving and ADAS.
+abstract: "This lecture introduced the fundamental concepts, architectures, and practical challenges of sensor fusion and scene understanding for AD/ADAS systems. Topics included multi-sensor perception pipelines, probabilistic fusion, object tracking, and the role of neural networks in modern autonomous driving stacks, with emphasis on real-world deployment considerations."
+
+date: '2026-03-02T09:00:00Z'
+date_end: '2026-03-02T17:00:00Z'
+all_day: false
+
+publishDate: '2026-03-02T00:00:00Z'
+
+authors: []
+tags: ["sensor fusion", "scene understanding", "ADAS", "autonomous driving"]
+
+featured: false
+
+image:
+  caption: 'Image credit: [**Unsplash**](https://unsplash.com/photos/bzdhc5b3Bxs)'
+  focal_point: Right
+
+links: []
+url_code: ""
+url_pdf: ""
+url_slides: ""
+url_video: ""
+
+slides: ""
+projects: []
+---
+
+{{% callout note %}}
+This page describes the lectio magistralis delivered at Centrale Nantes for the Datasim program in March 2026.
+{{% /callout %}}
+
+The lecture covered:
+
+- Overview of sensors used in autonomous driving (camera, LiDAR, radar, ultrasonic)
+- Classical and modern approaches to sensor fusion
+- Scene understanding for autonomous driving
+- Neural network-based perception pipelines
+- Real-world deployment challenges and considerations

--- a/content/event/ecn26/index.md
+++ b/content/event/ecn26/index.md
@@ -4,12 +4,12 @@ title: "Teaching: Sensor Fusion and Scene Understanding for AD/ADAS at Centrale 
 event: École Centrale Nantes
 event_url: https://www.ec-nantes.fr/
 
-location: ECN
+location: Centrale Nantes
 address:
-  street: 828 Boulevard des Maréchaux
-  city: Palaiseau
-  region: Ile-de-France
-  postcode: '91120'
+  street: 1 rue de la Noë
+  city: Nantes
+  region: Pays de la Loire
+  postcode: '44321'
   country: France
 
 summary: Lectio magistralis delivered for the ECN Datasim course, introducing key concepts in sensor fusion and scene understanding for autonomous driving and ADAS.


### PR DESCRIPTION
Adds event entry for the Datasim course lecture on Sensor Fusion and
Scene Understanding for AD/ADAS delivered at Centrale Nantes on 2 March 2026.

https://claude.ai/code/session_01DoPNipkNnaEv7moPNCv5gW