### PR TITLE
fix: remove email exposure and broken Calendly link

### DIFF
--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -47,7 +47,7 @@ education:
 social:
 - icon: envelope
   icon_pack: fas
-  link: 'mailto:'
+  link: '/#contact'
 - icon: graduation-cap  # Alternatively, use `google-scholar` icon from `ai` icon pack
   icon_pack: fas
   link: https://scholar.google.com/citations?user=ngkfvf8AAAAJ&hl=en

--- a/content/home/contact.md
+++ b/content/home/contact.md
@@ -44,7 +44,7 @@ content:
   #office_hours:
   #  - 'Monday 10:00 to 13:00'
   #  - 'Wednesday 09:00 to 10:00'
-  appointment_url: 'https://calendly.com'
+  #appointment_url: 'https://calendly.com'
   #contact_links:
   #  - icon: twitter
   #    icon_pack: fab


### PR DESCRIPTION
- Redirect envelope icon from bare mailto: to /#contact section
- Comment out placeholder appointment_url pointing to calendly.com homepage

Previous commits on this branch already removed the raw Gmail address
from three locations (social link, Gravatar field, contact widget).

https://claude.ai/code/session_019iRLQXZ495PgTkYENoiW41